### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 ## Force the azure pipeline merge
-
+## attempt 2
 trigger:
 - '*'
 


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.